### PR TITLE
feature/content-search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 *.ctxt
 .mtj.tmp/
+.yml
 
 # === Archives ===
 *.jar

--- a/src/main/generated/cultureinfo/culture_app/domain/QContentCategory.java
+++ b/src/main/generated/cultureinfo/culture_app/domain/QContentCategory.java
@@ -20,9 +20,9 @@ public class QContentCategory extends EntityPathBase<ContentCategory> {
 
     public static final QContentCategory contentCategory = new QContentCategory("contentCategory");
 
-    public final StringPath contentCategoryName = createString("contentCategoryName");
-
     public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
 
     public final ListPath<ContentSubcategory, QContentSubcategory> subcategories = this.<ContentSubcategory, QContentSubcategory>createList("subcategories", ContentSubcategory.class, QContentSubcategory.class, PathInits.DIRECT2);
 

--- a/src/main/generated/cultureinfo/culture_app/domain/QContentDetail.java
+++ b/src/main/generated/cultureinfo/culture_app/domain/QContentDetail.java
@@ -22,13 +22,17 @@ public class QContentDetail extends EntityPathBase<ContentDetail> {
 
     public static final QContentDetail contentDetail = new QContentDetail("contentDetail");
 
+    public final StringPath artistName = createString("artistName");
+
+    public final StringPath brandName = createString("brandName");
+
     public final ListPath<ContentFavorite, QContentFavorite> contentFavorite = this.<ContentFavorite, QContentFavorite>createList("contentFavorite", ContentFavorite.class, QContentFavorite.class, PathInits.DIRECT2);
 
     public final StringPath contentName = createString("contentName");
 
     public final QContentSmallCategory contentSmallCategory;
 
-    public final StringPath details = createString("details");
+    public final StringPath detailsJson = createString("detailsJson");
 
     public final DateTimePath<java.time.LocalDateTime> endDateTime = createDateTime("endDateTime", java.time.LocalDateTime.class);
 
@@ -41,6 +45,10 @@ public class QContentDetail extends EntityPathBase<ContentDetail> {
     public final StringPath picture = createString("picture");
 
     public final NumberPath<Long> price = createNumber("price", Long.class);
+
+    public final ListPath<ContentSession, QContentSession> sessions = this.<ContentSession, QContentSession>createList("sessions", ContentSession.class, QContentSession.class, PathInits.DIRECT2);
+
+    public final StringPath sportTeamName = createString("sportTeamName");
 
     public final DateTimePath<java.time.LocalDateTime> startDateTime = createDateTime("startDateTime", java.time.LocalDateTime.class);
 

--- a/src/main/generated/cultureinfo/culture_app/domain/QContentSession.java
+++ b/src/main/generated/cultureinfo/culture_app/domain/QContentSession.java
@@ -1,0 +1,55 @@
+package cultureinfo.culture_app.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QContentSession is a Querydsl query type for ContentSession
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QContentSession extends EntityPathBase<ContentSession> {
+
+    private static final long serialVersionUID = -543213321L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QContentSession contentSession = new QContentSession("contentSession");
+
+    public final QContentDetail contentDetail;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath infoJson = createString("infoJson");
+
+    public final DatePath<java.time.LocalDate> sessionDate = createDate("sessionDate", java.time.LocalDate.class);
+
+    public QContentSession(String variable) {
+        this(ContentSession.class, forVariable(variable), INITS);
+    }
+
+    public QContentSession(Path<? extends ContentSession> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QContentSession(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QContentSession(PathMetadata metadata, PathInits inits) {
+        this(ContentSession.class, metadata, inits);
+    }
+
+    public QContentSession(Class<? extends ContentSession> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.contentDetail = inits.isInitialized("contentDetail") ? new QContentDetail(forProperty("contentDetail"), inits.get("contentDetail")) : null;
+    }
+
+}
+

--- a/src/main/generated/cultureinfo/culture_app/domain/QContentSmallCategory.java
+++ b/src/main/generated/cultureinfo/culture_app/domain/QContentSmallCategory.java
@@ -22,13 +22,13 @@ public class QContentSmallCategory extends EntityPathBase<ContentSmallCategory> 
 
     public static final QContentSmallCategory contentSmallCategory = new QContentSmallCategory("contentSmallCategory");
 
-    public final StringPath ContentSmallCategoryName = createString("ContentSmallCategoryName");
-
     public final QContentSubcategory contentSubcategory;
 
     public final ListPath<ContentDetail, QContentDetail> details = this.<ContentDetail, QContentDetail>createList("details", ContentDetail.class, QContentDetail.class, PathInits.DIRECT2);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
 
     public QContentSmallCategory(String variable) {
         this(ContentSmallCategory.class, forVariable(variable), INITS);

--- a/src/main/generated/cultureinfo/culture_app/domain/QContentSubcategory.java
+++ b/src/main/generated/cultureinfo/culture_app/domain/QContentSubcategory.java
@@ -24,9 +24,9 @@ public class QContentSubcategory extends EntityPathBase<ContentSubcategory> {
 
     public final QContentCategory contentCategory;
 
-    public final StringPath contentSubcategoryName = createString("contentSubcategoryName");
-
     public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
 
     public final ListPath<ContentSmallCategory, QContentSmallCategory> smallCategories = this.<ContentSmallCategory, QContentSmallCategory>createList("smallCategories", ContentSmallCategory.class, QContentSmallCategory.class, PathInits.DIRECT2);
 

--- a/src/main/java/cultureinfo/culture_app/controller/ContentDetailController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/ContentDetailController.java
@@ -1,9 +1,13 @@
 package cultureinfo.culture_app.controller;
 
+import cultureinfo.culture_app.dto.request.ContentDetailCreateRequestDto;
+import cultureinfo.culture_app.dto.request.ContentDetailUpdateRequestDto;
+import cultureinfo.culture_app.dto.request.ContentSearchRequestDto;
 import cultureinfo.culture_app.dto.response.ContentDetailDto;
+import cultureinfo.culture_app.dto.response.ContentSummaryDto;
 import cultureinfo.culture_app.service.ContentDetailService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,23 +19,51 @@ public class ContentDetailController {
 
     private final ContentDetailService contentDetailService;
 
-    //콘텐츠 리스트 조회(카테고리 필터, 키워드 검색, 정렬, 페이징, 찜 여부 포함)
-    //url에 페이징 정보가 알아서 들어감
+    // 목록 조회: 대분류(main), 중분류(sub), 소분류(small) 모두 옵션으로 받아 필터링
+    // GET /api/contents?mainCategoryId=&subcategoryId=&smallCategoryId=&keyword=&...
+
     @GetMapping
-    public ResponseEntity<Slice<ContentDetailDto>> getContentDetails(
-            @RequestParam(required = false) Long categoryId,
-            @RequestParam(required = false) String keyword,
-            @RequestParam(defaultValue = "latest") String sortBy,
-            Pageable pageable
-    ) {
-        Slice<ContentDetailDto> details = contentDetailService.getContentDetails(categoryId, keyword, sortBy, pageable);
-        return ResponseEntity.ok(details);
+    public Slice<ContentSummaryDto> search(@Valid ContentSearchRequestDto req) {
+        return contentDetailService.search(req);
     }
 
-    //단일 콘텐츠 상세 조회(찜 여부 포함)
-    @GetMapping("/{contentDetailId}")
-    public ResponseEntity<ContentDetailDto> getContentDetail(@PathVariable Long contentDetailId) {
-        ContentDetailDto detail = contentDetailService.getContentDetail(contentDetailId);
-        return ResponseEntity.ok(detail);
+
+     // 단일 콘텐츠 상세 조회 (로그인 필요)
+     // GET /api/contents/{id}
+    @GetMapping("/{id}")
+    public ContentDetailDto getDetail(@PathVariable Long id) {
+        return contentDetailService.getContentDetail(id);
     }
+
+
+     // 콘텐츠 생성
+     // POST /api/contents
+    @PostMapping
+    public ContentDetailDto create(
+            @RequestBody @Valid ContentDetailCreateRequestDto req
+    ) {
+        return contentDetailService.createContentDetail(req);
+    }
+
+
+     // 콘텐츠 수정
+     // PUT /api/contents/{id}
+    @PutMapping("/{id}")
+    public ContentDetailDto update(
+            @PathVariable Long id,
+            @RequestBody @Valid ContentDetailUpdateRequestDto req
+    ) {
+        return contentDetailService.updateContentDetail(id, req);
+    }
+
+
+     // 콘텐츠 삭제
+     // DELETE /api/contents/{id}
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        contentDetailService.deleteContentDetail(id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/cultureinfo/culture_app/controller/ContentSessionController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/ContentSessionController.java
@@ -39,7 +39,6 @@ public class ContentSessionController {
     //세션 수정
     @PutMapping("/{sessionId}")
     public ContentSessionDto updateSession(
-            @PathVariable Long contentId,
             @PathVariable Long sessionId,
             @RequestBody @Valid ContentSessionUpdateRequestDto dto
     ) {
@@ -49,7 +48,6 @@ public class ContentSessionController {
     //세션 삭제
     @DeleteMapping("/{sessionId}")
     public ResponseEntity<Void> deleteSession(
-            @PathVariable Long contentId,
             @PathVariable Long sessionId
     ) {
         sessionService.deleteSession(sessionId);

--- a/src/main/java/cultureinfo/culture_app/controller/ContentSessionController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/ContentSessionController.java
@@ -1,0 +1,58 @@
+package cultureinfo.culture_app.controller;
+
+import cultureinfo.culture_app.dto.request.ContentSessionCreateRequestDto;
+import cultureinfo.culture_app.dto.request.ContentSessionUpdateRequestDto;
+import cultureinfo.culture_app.dto.response.ContentSessionDto;
+import cultureinfo.culture_app.service.ContentSessionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/contents/{contentId}/sessions")
+@RequiredArgsConstructor
+@Validated
+public class ContentSessionController {
+    private final ContentSessionService sessionService;
+
+    //특정 콘텐츠의 모든 세션 조회
+    @GetMapping
+    public List<ContentSessionDto> listSessions(@PathVariable Long contentId) {
+        return sessionService.getSessionsByContent(contentId);
+    }
+
+    //세션 생성
+    @PostMapping
+    public ResponseEntity<ContentSessionDto> createSession(
+            @PathVariable Long contentId,
+            @RequestBody @Valid ContentSessionCreateRequestDto dto
+    ) {
+        dto.setContentDetailId(contentId);
+        ContentSessionDto created = sessionService.createSession(dto);
+        return ResponseEntity.ok(created);
+    }
+
+    //세션 수정
+    @PutMapping("/{sessionId}")
+    public ContentSessionDto updateSession(
+            @PathVariable Long contentId,
+            @PathVariable Long sessionId,
+            @RequestBody @Valid ContentSessionUpdateRequestDto dto
+    ) {
+        return sessionService.updateSession(sessionId, dto);
+    }
+
+    //세션 삭제
+    @DeleteMapping("/{sessionId}")
+    public ResponseEntity<Void> deleteSession(
+            @PathVariable Long contentId,
+            @PathVariable Long sessionId
+    ) {
+        sessionService.deleteSession(sessionId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/cultureinfo/culture_app/controller/MemberController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/MemberController.java
@@ -146,7 +146,7 @@ MemberController {
     @PutMapping("/profile/announcement/{id}")
     public ResponseEntity<ArticleDto> updateAnnouncement(
             @PathVariable Long id,
-            @RequestBody AnnouncementUpdateDto requestDto) {
+            @RequestBody AnnouncementUpdateRequestDto requestDto) {
 
         ArticleDto updated = announcementService.updateAnnouncement(id, requestDto);
         return ResponseEntity.ok(updated);
@@ -170,8 +170,6 @@ MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    
-    
     // --- JWT 토큰 재발급 ---
 
     // 10) 토큰 재발급

--- a/src/main/java/cultureinfo/culture_app/domain/ContentCategory.java
+++ b/src/main/java/cultureinfo/culture_app/domain/ContentCategory.java
@@ -1,19 +1,28 @@
 package cultureinfo.culture_app.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 //콘텐츠 대분류
 public class ContentCategory {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String contentCategoryName; // 대분류 이름
+
+    @Column(nullable = false)
+    private String name; // 대분류 이름
 
     @OneToMany(mappedBy = "contentCategory", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ContentSubcategory> subcategories = new ArrayList<>();
 }
+

--- a/src/main/java/cultureinfo/culture_app/domain/ContentDetail.java
+++ b/src/main/java/cultureinfo/culture_app/domain/ContentDetail.java
@@ -1,55 +1,162 @@
 package cultureinfo.culture_app.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Entity
 @Getter
 @NoArgsConstructor
-//콘텐츠 세부
+//콘텐츠 세부 (소분류 상세의 루트)
 public class ContentDetail {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String contentName; // 콘텐츠 이름
+    @Column(nullable = false)
+    private String contentName; // 콘텐츠 이름(필수)
 
-    private LocalDateTime startDateTime; // 시작일자
-    private LocalDateTime endDateTime; // 종료일자
+    @Column(nullable = false)
+    private LocalDateTime startDateTime;// 시작일자(필수)
 
-    private String location; // 콘텐츠 지역
-    private Long price = 0L; // 콘텐츠 가격
+    @Column(nullable = false)
+    private LocalDateTime endDateTime; // 종료일자(필수)
 
-    private String picture; // 콘텐츠 사진 - URL 경로 설계 등 필요
+    @Column(nullable = false)
+    private String location; // 콘텐츠 지역(필수)
 
-    //가수명, 스포츠 팀명,
+    @Column(nullable = true)
+    private Long price = 0L; // 콘텐츠 가격(옵션)
+
+    @Column(nullable = true)
+    private String picture; // 콘텐츠 사진 - URL 경로 설계 등 필요(옵션)
+
+    @Column(nullable = true)
+    private String artistName; // 가수(그룹)명(옵션)
+
+    @Column(nullable = true)
+    private String sportTeamName;
+
+    @Column(nullable = true)// 스포츠 팀명(옵션)
+    private String brandName; // 브랜드 명(옵션)
 
     @Lob
-    private String details; // 각 컨테츠 별로 바뀌거나 조회가 필요 없는 세부내용
+    @Column(nullable = true)
+    private String detailsJson; // 각 컨테츠 별로 바뀌거나 조회가 필요 없는 세부내용 Json(옵션)
 
-    private Long favoriteCount; // 찜 개수
+    @Column(nullable = false)
+    private Long favoriteCount = 0L; // 찜 개수(필수)
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "content_small_category_id")
     private ContentSmallCategory contentSmallCategory;
 
-    @OneToMany(mappedBy = "contentDetail")
+    //콘텐츠 찜
+    @OneToMany(mappedBy = "contentDetail", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ContentFavorite> contentFavorite = new ArrayList<>();
 
+    //일별 콘텐츠 상세
+    @OneToMany(mappedBy = "contentDetail", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ContentSession> sessions = new ArrayList<>();
+
+    //찜 개수 증가
     public void increaseFavoriteCount() { // 찜 개수 증가
         this.favoriteCount++;
     }
 
-    public void decreaseFavoriteCount() { // 찜 개수 감소
+    // 찜 개수 감소
+    public void decreaseFavoriteCount() {
         if (this.favoriteCount > 0) {
             this.favoriteCount--;
         }
 
     }
 
+    //콘텐츠 이름 변경
+    public void changeContentName(String name) {
+        if(name == null || name.isBlank())
+            throw new IllegalArgumentException("콘텐츠 이름은 비울 수 없습니다.");
+        this.contentName = name;
+    }
+
+    // 시작/종료일자 동시 변경
+    public void changePeriod(LocalDateTime start, LocalDateTime end) {
+        if (start != null && end != null && end.isBefore(start)) {
+            throw new IllegalArgumentException("종료일자는 시작일자 이후여야 합니다.");
+        }
+        Optional.ofNullable(start).ifPresent(s -> this.startDateTime = s);
+        Optional.ofNullable(end).ifPresent(e -> this.endDateTime = e);
+    }
+
+    // 위치 변경 (옵션)
+    public void changeLocation(String location) {
+        Optional.ofNullable(location)
+                .filter(loc -> !loc.isBlank())
+                .ifPresent(loc -> this.location = loc);
+    }
+
+    // 사진 URL 변경 (옵션)
+    public void changePicture(String picture) {
+        Optional.ofNullable(picture)
+                .filter(url -> !url.isBlank())
+                .ifPresent(url -> this.picture = url);
+    }
+
+    //아티스트 명 변경
+    public void changeArtistName(String artist) {
+        Optional.ofNullable(artist)
+                .filter(a -> !a.isBlank())
+                .ifPresent(a -> this.artistName = a);
+    }
+
+    //스포츠 팀 명 변경
+    public void changeSportTeamName(String team) {
+        Optional.ofNullable(team)
+                .filter(t -> !t.isBlank())
+                .ifPresent(t -> this.sportTeamName = t);
+    }
+
+    //브랜드 명 변경
+    public void changeBrandName(String brand) {
+        Optional.ofNullable(brand)
+                .filter(b -> !b.isBlank())
+                .ifPresent(b -> this.brandName = b);
+    }
+
+    // 상세 JSON 변경 (옵션)
+    public void changeDetailsJson(String json) {
+        Optional.ofNullable(json)
+                .ifPresent(j -> this.detailsJson = j);
+    }
+    @Builder
+    public ContentDetail(String contentName,
+                         LocalDateTime startDateTime,
+                         LocalDateTime endDateTime,
+                         String location,
+                         Long price,
+                         String picture,
+                         String artistName,
+                         String sportTeamName,
+                         String brandName,
+                         String detailsJson,
+                         ContentSmallCategory contentSmallCategory) {
+        this.contentName = contentName;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+        this.location = location;
+        this.price = price == null ? 0L : price;
+        this.picture = picture;
+        this.artistName = artistName;
+        this.sportTeamName = sportTeamName;
+        this.brandName = brandName;
+        this.detailsJson = detailsJson;
+        this.contentSmallCategory = contentSmallCategory;
+        this.favoriteCount = 0L;
+    }
 
 }

--- a/src/main/java/cultureinfo/culture_app/domain/ContentSession.java
+++ b/src/main/java/cultureinfo/culture_app/domain/ContentSession.java
@@ -1,0 +1,35 @@
+package cultureinfo.culture_app.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+//일별 세션(소분류 상세)
+public class ContentSession {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private ContentDetail contentDetail; //
+
+    @Column(nullable = false)
+    private LocalDate sessionDate;
+
+    @Lob
+    @Column(nullable = true)
+    private String infoJson; // 세션별 추가 정보
+
+    public void changeSessionDate(LocalDate sessionDate) {
+        this.sessionDate = sessionDate;
+    }
+
+    public void changeInfoJson(String infoJson) {
+        this.infoJson = infoJson;
+    }
+}

--- a/src/main/java/cultureinfo/culture_app/domain/ContentSmallCategory.java
+++ b/src/main/java/cultureinfo/culture_app/domain/ContentSmallCategory.java
@@ -10,13 +10,14 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
+//콘텐츠 소분류
 public class ContentSmallCategory {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String ContentSmallCategoryName; // 콘텐츠 소분류 "2025 봄 대동제" 등
+    private String name; // 콘텐츠 소분류 "2025 봄 대동제" 등
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) // optional = false 조건은 연관관계가 무조건 있어야 함을 표시
     @JoinColumn(name = "content_subcategory_id")
     private ContentSubcategory contentSubcategory;
 

--- a/src/main/java/cultureinfo/culture_app/domain/ContentSubcategory.java
+++ b/src/main/java/cultureinfo/culture_app/domain/ContentSubcategory.java
@@ -1,21 +1,28 @@
 package cultureinfo.culture_app.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 //콘텐츠 중분류
 public class ContentSubcategory {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String contentSubcategoryName; // 콘텐츠 중분류
+    @Column(nullable = false)
+    private String name; // 콘텐츠 중분류
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) // optional = false 조건은 연관관계가 무조건 있어야 함을 표시
     @JoinColumn(name = "content_category_id")
     private ContentCategory contentCategory;
 

--- a/src/main/java/cultureinfo/culture_app/dto/request/AnnouncementUpdateRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/AnnouncementUpdateRequestDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class AnnouncementUpdateDto {
+public class AnnouncementUpdateRequestDto {
     private String title;
     private String body;
 

--- a/src/main/java/cultureinfo/culture_app/dto/request/ContentDetailCreateRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/ContentDetailCreateRequestDto.java
@@ -1,0 +1,38 @@
+package cultureinfo.culture_app.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentDetailCreateRequestDto {
+    @NotNull
+    private Long contentSmallCategoryId;
+
+    @NotBlank
+    private String contentName;
+
+    @NotNull
+    private LocalDateTime startDateTime;
+
+    @NotNull
+    private LocalDateTime endDateTime;
+
+    @NotBlank
+    private String location;
+
+    private Long price;
+    private String picture;
+    private String artistName;
+    private String sportTeamName;
+    private String brandName;
+    private String detailsJson;
+}

--- a/src/main/java/cultureinfo/culture_app/dto/request/ContentDetailUpdateRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/ContentDetailUpdateRequestDto.java
@@ -1,0 +1,28 @@
+package cultureinfo.culture_app.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+//콘텐츠 수정 요청용 dto
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentDetailUpdateRequestDto {
+    private Long id; // 콘텐츠 상세 id
+    private String contentName; // 콘텐츠 이름
+    private LocalDateTime startDateTime; // 콘텐츠 시작 시간
+    private LocalDateTime endDateTime; // 콘텐츠 종료 시간
+    private Long favoriteCount; // 찜 개수
+    private String picture; // 들어가는 사진 url
+    private String location; // 콘텐츠 위치
+    private Long price; // 콘텐츠 가격
+    private String artistName; // 가수 이름
+    private String sportTeamName; // 스포츠 팀 이름
+    private String brandName; // 팝업 브랜드 이름
+    private String detailsJson;
+}

--- a/src/main/java/cultureinfo/culture_app/dto/request/ContentSearchRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/ContentSearchRequestDto.java
@@ -1,0 +1,28 @@
+package cultureinfo.culture_app.dto.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+//콘텐츠 검색 요청용 dto
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+//보류
+public class ContentSearchRequestDto {
+    private Long categoryId;    // 대분류(또는 중분류·소분류) ID
+    private Long subCategoryId; // 중분류
+    private Long smallCategoryId; // 소분류
+    private String keyword;     // 콘텐츠 이름 검색
+    private String artistName; // 가수명 검색 키워드
+    private String sportTeamName;   // 스포츠 팀명 검색 키워드
+    private String brandName;       // 브랜드명 검색 키워드
+    private String sortBy;      // "favoriteCount", "startDateTime" 등
+
+    @Min(0)
+    private int   page = 0;         // 0부터 시작
+    @Min(1)
+    private int   size = 20;         // 페이지 크기
+}

--- a/src/main/java/cultureinfo/culture_app/dto/request/ContentSessionCreateRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/ContentSessionCreateRequestDto.java
@@ -1,0 +1,25 @@
+package cultureinfo.culture_app.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import software.amazon.awssdk.annotations.NotNull;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@AllArgsConstructor
+
+//일별 세션 생성 요청
+public class ContentSessionCreateRequestDto {
+    @NotNull
+    private Long contentDetailId;
+
+    @NotNull
+    private LocalDate sessionDate;
+
+    private String infoJson;
+}

--- a/src/main/java/cultureinfo/culture_app/dto/request/ContentSessionUpdateRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/ContentSessionUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package cultureinfo.culture_app.dto.request;
+
+import lombok.*;
+import software.amazon.awssdk.annotations.NotNull;
+
+import java.time.LocalDate;
+
+//일별 세션 수정 요청
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentSessionUpdateRequestDto {
+    @NotNull
+    private LocalDate sessionDate;
+    private String infoJson;
+}

--- a/src/main/java/cultureinfo/culture_app/dto/response/ContentDetailDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/response/ContentDetailDto.java
@@ -6,27 +6,50 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
-public class ContentDetailDto {
-    private Long id;
-    private String contentName;
-    private String picture;
-    private LocalDateTime startDateTime;
-    private LocalDateTime endDateTime;
-    private boolean isFavorite;
-    private Long favoriteCount;
 
-    public static ContentDetailDto from(ContentDetail detail, boolean isFavorited) {
+//콘텐츠 상세페이지 용 responseDto
+public class ContentDetailDto {
+    private Long id; // 콘텐츠 상세 id
+    private String contentName; // 콘텐츠 이름
+    private LocalDateTime startDateTime; // 콘텐츠 시작 시간
+    private LocalDateTime endDateTime; // 콘텐츠 종료 시간
+    private String location; // 콘텐츠 위치
+    private boolean isFavorite; // 찜 여부
+    private Long favoriteCount; // 찜 개수
+    private String picture; // 들어가는 사진 url
+    private Long price; // 콘텐츠 가격
+    private String artistName; // 가수 이름
+    private String sportTeamName; // 스포츠 팀 이름
+    private String brandName; // 팝업 브랜드 이름
+    private List<SessionDto> sessions; // 일별 세션
+    private String detailsJson; // 세부정보
+
+
+    public static ContentDetailDto from(ContentDetail d, boolean fav) {
+        List<SessionDto> sessions = d.getSessions().stream()
+                .map(s -> new SessionDto(s.getId(), s.getSessionDate(), s.getInfoJson()))
+                .toList();
+
         return ContentDetailDto.builder()
-                .id(detail.getId())
-                .contentName(detail.getContentName())
-                .picture(detail.getPicture())
-                .startDateTime(detail.getStartDateTime())
-                .endDateTime(detail.getEndDateTime())
-                .isFavorite(isFavorited)
-                .favoriteCount(detail.getFavoriteCount())
+                .id(d.getId())
+                .contentName(d.getContentName())
+                .picture(d.getPicture())
+                .startDateTime(d.getStartDateTime())
+                .endDateTime(d.getEndDateTime())
+                .location(d.getLocation())
+                .price(d.getPrice())
+                .isFavorite(fav)
+                .favoriteCount(d.getFavoriteCount())
+                .sessions(sessions)
+                .artistName(d.getArtistName())
+                .sportTeamName(d.getSportTeamName())
+                .brandName(d.getBrandName())
+                .detailsJson(d.getDetailsJson())
                 .build();
     }
 }

--- a/src/main/java/cultureinfo/culture_app/dto/response/ContentFavoriteDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/response/ContentFavoriteDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+//콘텐츠 찜 토글/상태 dto
 public class ContentFavoriteDto {
     private boolean isFavorite;
     private Long favoriteCount;

--- a/src/main/java/cultureinfo/culture_app/dto/response/ContentSessionDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/response/ContentSessionDto.java
@@ -1,0 +1,15 @@
+package cultureinfo.culture_app.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
+public class ContentSessionDto {
+    private Long id;
+    private LocalDate sessionDate;
+    private String infoJson;
+}

--- a/src/main/java/cultureinfo/culture_app/dto/response/ContentSummaryDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/response/ContentSummaryDto.java
@@ -1,0 +1,28 @@
+package cultureinfo.culture_app.dto.response;
+
+import cultureinfo.culture_app.domain.ContentDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ContentSummaryDto {
+    private Long id;
+    private String contentName; // 콘텐츠 제목
+    private String picture; // 콘텐츠 목록용 사진 url
+    private LocalDateTime startDateTime; // 시작 날짜
+    private LocalDateTime endDateTime; // 종료 날짜
+
+    public static ContentSummaryDto of(ContentDetail d) {
+        return ContentSummaryDto.builder()
+                .id(d.getId())
+                .contentName(d.getContentName())
+                .picture(d.getPicture())
+                .startDateTime(d.getStartDateTime())
+                .endDateTime(d.getEndDateTime())
+                .build();
+    }
+
+}

--- a/src/main/java/cultureinfo/culture_app/repository/ContentCategoryRepository.java
+++ b/src/main/java/cultureinfo/culture_app/repository/ContentCategoryRepository.java
@@ -1,0 +1,9 @@
+package cultureinfo.culture_app.repository;
+
+import cultureinfo.culture_app.domain.ContentCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContentCategoryRepository extends JpaRepository<ContentCategory, Long> {
+}

--- a/src/main/java/cultureinfo/culture_app/repository/ContentDetailRepositoryCustom.java
+++ b/src/main/java/cultureinfo/culture_app/repository/ContentDetailRepositoryCustom.java
@@ -1,11 +1,20 @@
 package cultureinfo.culture_app.repository;
 
-import cultureinfo.culture_app.dto.response.ContentDetailDto;
+import cultureinfo.culture_app.dto.response.ContentSummaryDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface ContentDetailRepositoryCustom {
-    Slice<ContentDetailDto> searchContentDetails(
-            Long categoryId, String keyword, String sortBy, Pageable pageable, Long memberId
+    Slice<ContentSummaryDto> searchContentDetails(
+            Long categoryId,
+            Long subCategoryId,
+            Long smallCategoryId,
+            String keyword,
+            String artistName,
+            String sportTeamName,
+            String brandName,
+            String sortBy,
+            Pageable pageable,
+            Long memberId
     );
 }

--- a/src/main/java/cultureinfo/culture_app/repository/ContentSessionRepository.java
+++ b/src/main/java/cultureinfo/culture_app/repository/ContentSessionRepository.java
@@ -1,0 +1,9 @@
+package cultureinfo.culture_app.repository;
+
+import cultureinfo.culture_app.domain.ContentSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContentSessionRepository extends JpaRepository<ContentSession, Long> {
+}

--- a/src/main/java/cultureinfo/culture_app/repository/ContentSmallCategoryRepository.java
+++ b/src/main/java/cultureinfo/culture_app/repository/ContentSmallCategoryRepository.java
@@ -1,0 +1,9 @@
+package cultureinfo.culture_app.repository;
+
+import cultureinfo.culture_app.domain.ContentSmallCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContentSmallCategoryRepository extends JpaRepository<ContentSmallCategory, Long> {
+}

--- a/src/main/java/cultureinfo/culture_app/repository/ContentSubCategoryRepository.java
+++ b/src/main/java/cultureinfo/culture_app/repository/ContentSubCategoryRepository.java
@@ -1,0 +1,9 @@
+package cultureinfo.culture_app.repository;
+
+import cultureinfo.culture_app.domain.ContentSubcategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContentSubCategoryRepository extends JpaRepository<ContentSubcategory, Long> {
+}

--- a/src/main/java/cultureinfo/culture_app/service/AnnouncementService.java
+++ b/src/main/java/cultureinfo/culture_app/service/AnnouncementService.java
@@ -3,7 +3,7 @@ package cultureinfo.culture_app.service;
 import cultureinfo.culture_app.domain.Member;
 import cultureinfo.culture_app.domain.type.ArticleCategory;
 import cultureinfo.culture_app.dto.request.AnnouncementRequestDto;
-import cultureinfo.culture_app.dto.request.AnnouncementUpdateDto;
+import cultureinfo.culture_app.dto.request.AnnouncementUpdateRequestDto;
 
 import cultureinfo.culture_app.dto.response.ArticleDto;
 import cultureinfo.culture_app.repository.MemberRepository;
@@ -84,7 +84,7 @@ public class AnnouncementService {
 
     // 수정: ADMIN만 가능
     @Transactional
-    public ArticleDto updateAnnouncement(Long announcemnetId, AnnouncementUpdateDto request) {
+    public ArticleDto updateAnnouncement(Long announcemnetId, AnnouncementUpdateRequestDto request) {
         Long memberId = securityUtil.getCurrentId();
         if (memberId == null) {
             throw new AccessDeniedException("로그인이 필요합니다.");

--- a/src/main/java/cultureinfo/culture_app/service/ContentDetailService.java
+++ b/src/main/java/cultureinfo/culture_app/service/ContentDetailService.java
@@ -1,38 +1,96 @@
 package cultureinfo.culture_app.service;
 
 import cultureinfo.culture_app.domain.ContentDetail;
+import cultureinfo.culture_app.domain.ContentSmallCategory;
+import cultureinfo.culture_app.domain.Member;
+import cultureinfo.culture_app.dto.request.ContentDetailCreateRequestDto;
+import cultureinfo.culture_app.dto.request.ContentDetailUpdateRequestDto;
+import cultureinfo.culture_app.dto.request.ContentSearchRequestDto;
 import cultureinfo.culture_app.dto.response.ContentDetailDto;
+import cultureinfo.culture_app.dto.response.ContentSummaryDto;
 import cultureinfo.culture_app.repository.ContentDetailRepository;
+import cultureinfo.culture_app.repository.ContentSmallCategoryRepository;
+import cultureinfo.culture_app.repository.MemberRepository;
 import cultureinfo.culture_app.security.SecurityUtil;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class ContentDetailService {
     private final ContentDetailRepository contentDetailRepository;
+    private final ContentSmallCategoryRepository contentSmallCategoryRepository;
     private final SecurityUtil securityUtil;
     private final ContentFavoriteService contentFavoriteService;
+    private final MemberRepository memberRepository;
+
+    //콘텐츠- 관리자만 생성 가능
+    @Transactional
+    public ContentDetailDto createContentDetail(ContentDetailCreateRequestDto req) {
+        // 1) 로그인 및 관리자 권한 확인
+        Long memberId = securityUtil.getCurrentId();
+        if (memberId == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+        boolean isAdmin = member.getRoles().stream()
+                .anyMatch(r -> r.getAuthority().equals("ROLE_ADMIN"));
+        if (!isAdmin) {
+            throw new AccessDeniedException("관리자 권한이 필요합니다.");
+        }
+
+        // 2) 소분류(Category) 조회
+        ContentSmallCategory smallCat = contentSmallCategoryRepository
+                .findById(req.getContentSmallCategoryId())
+                .orElseThrow(() -> new EntityNotFoundException("소분류가 존재하지 않습니다."));
+
+        // 3) 엔티티 빌드
+        ContentDetail entity = ContentDetail.builder()
+                .contentName(req.getContentName())
+                .startDateTime(req.getStartDateTime())
+                .endDateTime(req.getEndDateTime())
+                .location(req.getLocation())
+                .price(Optional.ofNullable(req.getPrice()).orElse(0L))
+                .picture(req.getPicture())
+                .artistName(req.getArtistName())
+                .sportTeamName(req.getSportTeamName())
+                .brandName(req.getBrandName())
+                .detailsJson(req.getDetailsJson())
+                .contentSmallCategory(smallCat)
+                .build();
+
+        // 4) 저장
+        contentDetailRepository.save(entity);
+
+        // 5) 반환용 DTO 변환 (찜 여부는 false로 초기화하거나 별도 로직)
+        boolean isFav = contentFavoriteService.isFavorite(memberId, entity.getId());
+        return ContentDetailDto.from(entity, isFav);
+    }
 
     @Transactional(readOnly = true)
     //페이지 단위 콘텐츠 리스트 조회(필터, 검색, 정렬, 페이징, 찜 여부 포함)
-    public Slice<ContentDetailDto> getContentDetails(
-            Long categoryId,
-            String keyword,
-            String sortBy,
-            Pageable pageable
-    ){
+    public Slice<ContentSummaryDto> search(ContentSearchRequestDto req){
         Long memberId = securityUtil.getCurrentId();
-        if(memberId == null) {
-            throw new AccessDeniedException("로그인이 필요합니다");
-        }
         return contentDetailRepository.searchContentDetails(
-                categoryId, keyword, sortBy, pageable, memberId
-        );
+                req.getCategoryId(),
+                req.getSubCategoryId(),
+                req.getSmallCategoryId(),
+                req.getKeyword(),
+                req.getArtistName(),
+                req.getSportTeamName(),
+                req.getBrandName(),
+                req.getSortBy(),
+                PageRequest.of(req.getPage(), req.getSize()), // 몇 번째 페이지에서 몇 개의 콘텐츠를 가져올지
+                memberId);
     }
 
     //단일 콘텐츠 상세 조회
@@ -45,9 +103,75 @@ public class ContentDetailService {
 
         ContentDetail contentDetail = contentDetailRepository.findById(contentDetailId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 콘텐츠입니다."));
-        boolean isFavorited = contentFavoriteService.isFavorite(memberId,contentDetailId);
+        boolean isFavorited = contentFavoriteService.isFavorite(memberId,contentDetailId); // 어떻게 처리할지 생각 필요
         return ContentDetailDto.from(contentDetail, isFavorited);
+    }
 
+    //콘텐츠 상세 수정 - 관리자만 수정 가능
+    @Transactional
+    public ContentDetailDto updateContentDetail(
+            Long contentDetailId,
+            ContentDetailUpdateRequestDto dto
+    ) {
+        Long memberId = securityUtil.getCurrentId();
+        if (memberId == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+
+        boolean isAdmin = member.getRoles().stream()
+                .anyMatch(role -> role.getAuthority().equals("ROLE_ADMIN"));
+
+        if (!isAdmin) {
+            throw new AccessDeniedException("글 작성 권한이 없습니다.");
+        }
+        ContentDetail entity = contentDetailRepository.findById(contentDetailId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 콘텐츠입니다."));
+
+        // DTO에 담긴 값만 선택적으로 업데이트
+        if (dto.getContentName() != null)
+            entity.changeContentName(dto.getContentName());
+        if (dto.getStartDateTime() != null|| dto.getEndDateTime() != null)
+            entity.changePeriod(dto.getStartDateTime(), dto.getEndDateTime());
+        if (dto.getLocation() != null)
+            entity.changeLocation(dto.getLocation());
+        if (dto.getPicture() != null)
+            entity.changePicture(dto.getPicture());
+        if (dto.getArtistName() != null)
+            entity.changeArtistName(dto.getArtistName());
+        if (dto.getSportTeamName() != null)
+            entity.changeSportTeamName(dto.getSportTeamName());
+        if (dto.getBrandName() != null)
+            entity.changeBrandName(dto.getBrandName());
+        if (dto.getDetailsJson() != null)
+            entity.changeDetailsJson(dto.getDetailsJson());
+
+        // 변경된 엔티티를 다시 DTO로 변환해 반환
+        boolean fav = contentFavoriteService.isFavorite(securityUtil.getCurrentId(), contentDetailId);
+        return ContentDetailDto.from(entity, fav);
+    }
+
+    //콘텐츠 삭제
+    public void deleteContentDetail(Long contentDetailId) {
+        Long memberId = securityUtil.getCurrentId();
+        if (memberId == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+
+        boolean isAdmin = member.getRoles().stream()
+                .anyMatch(role -> role.getAuthority().equals("ROLE_ADMIN"));
+
+        if (!isAdmin) {
+            throw new AccessDeniedException("글 작성 권한이 없습니다.");
+        }
+
+        if (!contentDetailRepository.existsById(contentDetailId)) {
+            throw new IllegalArgumentException("존재하지 않는 콘텐츠입니다.");
+        }
+        contentDetailRepository.deleteById(contentDetailId);
     }
 
 }

--- a/src/main/java/cultureinfo/culture_app/service/ContentDetailService.java
+++ b/src/main/java/cultureinfo/culture_app/service/ContentDetailService.java
@@ -15,7 +15,6 @@ import cultureinfo.culture_app.security.SecurityUtil;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;

--- a/src/main/java/cultureinfo/culture_app/service/ContentSessionService.java
+++ b/src/main/java/cultureinfo/culture_app/service/ContentSessionService.java
@@ -6,7 +6,6 @@ import cultureinfo.culture_app.domain.Member;
 import cultureinfo.culture_app.dto.request.ContentSessionCreateRequestDto;
 import cultureinfo.culture_app.dto.request.ContentSessionUpdateRequestDto;
 import cultureinfo.culture_app.dto.response.ContentSessionDto;
-import cultureinfo.culture_app.dto.response.SessionDto;
 import cultureinfo.culture_app.repository.ContentDetailRepository;
 import cultureinfo.culture_app.repository.ContentSessionRepository;
 import cultureinfo.culture_app.repository.MemberRepository;

--- a/src/main/java/cultureinfo/culture_app/service/ContentSessionService.java
+++ b/src/main/java/cultureinfo/culture_app/service/ContentSessionService.java
@@ -1,0 +1,115 @@
+package cultureinfo.culture_app.service;
+
+import cultureinfo.culture_app.domain.ContentDetail;
+import cultureinfo.culture_app.domain.ContentSession;
+import cultureinfo.culture_app.domain.Member;
+import cultureinfo.culture_app.dto.request.ContentSessionCreateRequestDto;
+import cultureinfo.culture_app.dto.request.ContentSessionUpdateRequestDto;
+import cultureinfo.culture_app.dto.response.ContentSessionDto;
+import cultureinfo.culture_app.dto.response.SessionDto;
+import cultureinfo.culture_app.repository.ContentDetailRepository;
+import cultureinfo.culture_app.repository.ContentSessionRepository;
+import cultureinfo.culture_app.repository.MemberRepository;
+import cultureinfo.culture_app.security.SecurityUtil;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ContentSessionService {
+    private final ContentSessionRepository contentSessionRepository;
+    private final ContentDetailRepository contentDetailRepository;
+    private final MemberRepository memberRepository;
+    private final SecurityUtil securityUtil;
+
+    //특정 콘텐츠의 모든 세션 조회
+    @Transactional(readOnly = true)
+    public List<ContentSessionDto> getSessionsByContent(Long contentDetailId){
+        ContentDetail detail = contentDetailRepository.findById(contentDetailId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 콘텐츠입니다."));
+        return detail.getSessions().stream()
+                .map(s -> new ContentSessionDto(s.getId(), s.getSessionDate(), s.getInfoJson()))
+                .collect(Collectors.toList());
+    }
+
+    //세션 생성 - 관리자만
+    @Transactional
+    public ContentSessionDto createSession(ContentSessionCreateRequestDto dto) {
+
+        // 1) 로그인 및 관리자 권한 확인
+        Long memberId = securityUtil.getCurrentId();
+        if (memberId == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+        boolean isAdmin = member.getRoles().stream()
+                .anyMatch(r -> r.getAuthority().equals("ROLE_ADMIN"));
+        if (!isAdmin) {
+            throw new AccessDeniedException("관리자 권한이 필요합니다.");
+        }
+
+        ContentDetail detail = contentDetailRepository.findById(dto.getContentDetailId())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 콘텐츠입니다."));
+        ContentSession session = ContentSession.builder()
+                .contentDetail(detail)
+                .sessionDate(dto.getSessionDate())
+                .infoJson(dto.getInfoJson())
+                .build();
+
+        contentSessionRepository.save(session);
+        return new ContentSessionDto(session.getId(), session.getSessionDate(), session.getInfoJson());
+    }
+
+    @Transactional
+    public ContentSessionDto updateSession(Long sessionId, ContentSessionUpdateRequestDto dto) {
+        // 1) 로그인 및 관리자 권한 확인
+        Long memberId = securityUtil.getCurrentId();
+        if (memberId == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+        boolean isAdmin = member.getRoles().stream()
+                .anyMatch(r -> r.getAuthority().equals("ROLE_ADMIN"));
+        if (!isAdmin) {
+            throw new AccessDeniedException("관리자 권한이 필요합니다.");
+        }
+
+        ContentSession session = contentSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 세션입니다."));
+        session.changeSessionDate(dto.getSessionDate());
+        if (dto.getInfoJson() != null) {
+            session.changeInfoJson(dto.getInfoJson());
+        }
+        return new ContentSessionDto(session.getId(), session.getSessionDate(), session.getInfoJson());
+    }
+
+    @Transactional
+    public void deleteSession(Long sessionId) {
+        // 1) 로그인 및 관리자 권한 확인
+        Long memberId = securityUtil.getCurrentId();
+        if (memberId == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+        boolean isAdmin = member.getRoles().stream()
+                .anyMatch(r -> r.getAuthority().equals("ROLE_ADMIN"));
+        if (!isAdmin) {
+            throw new AccessDeniedException("관리자 권한이 필요합니다.");
+        }
+
+        if (!contentSessionRepository.existsById(sessionId)) {
+            throw new EntityNotFoundException("존재하지 않는 세션입니다.");
+        }
+        contentSessionRepository.deleteById(sessionId);
+    }
+
+}


### PR DESCRIPTION
# 콘텐츠 관리 기능 구현

## 개요
- 대분류 · 중분류 · 소분류 · 상세(ContentDetail) → 세션(ContentSession) 계층의 도메인 모델 설계
- 사용자 개별 “찜(Favorite)” 기능, 검색·필터링·페이징(Slice) 로직 포함
- 관리자 전용 콘텐츠 생성·수정·삭제 · 세션 생성·수정·삭제
- Spring Security 권한 체크

## 주요 변경사항

### 1. 도메인/엔티티
- `ContentCategory`(대분류), `ContentSubcategory`(중분류), `ContentSmallCategory`(소분류)
- `ContentDetail` (행사 상세)
    - `List<ContentSession>`: 날짜·회차별 세션
    - `List<ContentFavorite>`: 찜 정보
- `ContentSession`: 개별 세션 정보

### 2. 검색 · 목록 조회
- `ContentSearchRequestDto` 로 카테고리(대/중/소) · 키워드 · 아티스트 · 팀 · 브랜드 · 정렬 · 페이징 파라미터 수집
- QueryDSL 기반 `ContentDetailRepositoryCustomImpl#searchContentDetails(...)` 구현
- `ContentSummaryDto` (목록 응답), `ContentDetailDto` (상세 응답)

### 3. 상세 조회 · 찜
- 로그인 사용자만 상세 조회 가능(`AccessDeniedException` 처리)
- `ContentFavoriteService` 로 찜 토글·상태 제공
- 상세페이지에 세션 목록(`SessionDto`) 포함

### 4. 관리자 기능
- **콘텐츠**
    - `POST /api/contents` : 생성
    - `PUT  /api/contents/{id}` : 수정
    - `DELETE /api/contents/{id}` : 삭제
- **세션**
    - `GET    /api/contents/{id}/sessions` : 조회
    - `POST   /api/contents/{id}/sessions` : 세션 생성
    - `PUT    /api/contents/{id}/sessions/{sid}` : 세션 수정
    - `DELETE /api/contents/{id}/sessions/{sid}` : 세션 삭제


### 5. 페이징(Slice)
- `PageRequest.of(page, size)` 로 요청
- `SliceImpl<T>` 반환 → `hasNext` 정보만 제공, 무한 스크롤 최적화

