### PR TITLE
Exception

### DIFF
--- a/src/main/java/cultureinfo/culture_app/config/SecurityConfig.java
+++ b/src/main/java/cultureinfo/culture_app/config/SecurityConfig.java
@@ -73,7 +73,8 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/members/join/**", "/api/members/sign-in", "/api/members/reissue")
+                        .requestMatchers("/api/members/join", "/api/members/sign-in", "/api/members/reissue", "/api/members/join/send-email", "/error",
+                        "/api/members/find-username", "/api/members/find-password/temp")
                         .permitAll()
                         .requestMatchers("/test")
                         .hasRole("USER")

--- a/src/main/java/cultureinfo/culture_app/controller/ArticleController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/ArticleController.java
@@ -5,6 +5,7 @@ import cultureinfo.culture_app.dto.request.ArticleUpdateDto;
 import cultureinfo.culture_app.dto.response.ArticleDto;
 import cultureinfo.culture_app.dto.response.ArticleSummaryDto;
 import cultureinfo.culture_app.service.ArticleService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,10 +25,16 @@ public class ArticleController {
     //게시글 생성
     @PostMapping
     public ResponseEntity<ArticleDto> createArticle(@RequestBody ArticleRequestDto requestDto) {
-        ArticleDto created = articleService.createArticle(requestDto);
-        return ResponseEntity
+        try{
+            ArticleDto created = articleService.createArticle(requestDto);
+            return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(created);
+        } catch (EntityNotFoundException e){
+            return ResponseEntity.status(401).build(); //멤버가 존재하지 않거나 콘텐츠가 존재하지 않을때
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 게시글 단건 조회
@@ -61,15 +69,26 @@ public class ArticleController {
     public ResponseEntity<ArticleDto> updateArticle(
             @PathVariable Long id,
             @RequestBody ArticleUpdateDto requestDto) {
-
-        ArticleDto updated = articleService.updateArticle(id, requestDto);
-        return ResponseEntity.ok(updated);
+        try{
+            ArticleDto updated = articleService.updateArticle(id, requestDto);
+            return ResponseEntity.ok(updated);
+        } catch(AccessDeniedException e){
+            return ResponseEntity.status(401).build();
+        } catch (Exception e){
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 게시글 삭제
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteArticle(@PathVariable Long id) {
-        articleService.deleteArticle(id);
-        return ResponseEntity.noContent().build();
+        try{
+            articleService.deleteArticle(id);
+            return ResponseEntity.noContent().build();
+        } catch(AccessDeniedException e){
+            return ResponseEntity.status(401).build();
+        } catch (Exception e){
+            return ResponseEntity.status(500).build();
+        }
     }
 }

--- a/src/main/java/cultureinfo/culture_app/controller/CommentController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/CommentController.java
@@ -4,8 +4,10 @@ package cultureinfo.culture_app.controller;
 import cultureinfo.culture_app.dto.request.CommentRequestDto;
 import cultureinfo.culture_app.dto.response.CommentDto;
 import cultureinfo.culture_app.service.CommentService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -20,9 +22,14 @@ public class CommentController {
     public ResponseEntity<CommentDto> createComment(
             @PathVariable Long articleId,
             @RequestBody CommentRequestDto requestDto) {
-
-        CommentDto created = commentService.createComment(articleId, requestDto);
-        return ResponseEntity.ok(created);
+        try{
+            CommentDto created = commentService.createComment(articleId, requestDto);
+            return ResponseEntity.ok(created);
+        } catch (EntityNotFoundException e){
+            return ResponseEntity.status(401).build(); //멤버가 존재하지 않거나 콘텐츠가 존재하지 않을때
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 게시글 댓글 전체 조회
@@ -36,16 +43,26 @@ public class CommentController {
     public ResponseEntity<CommentDto> updateComment(
             @PathVariable Long commentId,
             @RequestBody CommentRequestDto requestDto) {
-
-        CommentDto updated = commentService.updateComment(commentId, requestDto);
-        return ResponseEntity.ok(updated);
+        try{
+            CommentDto updated = commentService.updateComment(commentId, requestDto);
+            return ResponseEntity.ok(updated);
+        } catch(AccessDeniedException e){
+            return ResponseEntity.status(401).build();
+        } catch (Exception e){
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 댓글 삭제
     @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
-
-        commentService.deleteComment(commentId);
-        return ResponseEntity.noContent().build();
+        try{
+            commentService.deleteComment(commentId);
+            return ResponseEntity.noContent().build();
+        } catch(AccessDeniedException e){
+            return ResponseEntity.status(401).build();
+        } catch (Exception e){
+            return ResponseEntity.status(500).build();
+        }
     }
 }

--- a/src/main/java/cultureinfo/culture_app/controller/MemberController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/MemberController.java
@@ -54,12 +54,12 @@ MemberController {
     public ResponseEntity<String> join(@Valid @RequestBody JoinRequestDTO req) {
         try{
             if (!emailService.verifyAuthCode(req.getEmail(), req.getAuthcode())) {
-                return ResponseEntity.status(400).body("Email Verification");
+                return ResponseEntity.status(401).body("Email Verification");
             }
             String username = memberService.join(req);
             return ResponseEntity.status(HttpStatus.CREATED).body(username); //201
         } catch (IllegalArgumentException e) { 
-            return ResponseEntity.status(400).body(e.getMessage()); //아이디 혹은 이메일 중복
+            return ResponseEntity.status(401).body(e.getMessage()); //아이디 혹은 이메일 중복
         } catch (Exception e) {
             return ResponseEntity.status(500).body(e.getMessage());
         }

--- a/src/main/java/cultureinfo/culture_app/controller/MemberController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/MemberController.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -31,85 +32,150 @@ MemberController {
     private final ArticleService articleService;
     private final AnnouncementService announcementService;
 
-    // --- 회원가입 및 로그임 ---
+    //
+
+    // --- 회원가입 및 로그인 ---
 
     //회원가입 인증용 이메일 전송
+    //이메일 형식 틀리면 400에러
     @PostMapping("/join/send-email")
-    public ResponseEntity<Void> sendJoinEmail(@RequestParam String email) {
-        emailService.sendJoinEmail(email);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<Void> sendJoinEmail(@Valid @RequestBody JoinEmailRequestDto email) {
+        try{
+            emailService.sendJoinEmail(email.getEmail());
+            return ResponseEntity.noContent().build(); //204
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     //회원가입
+    //400 에러는 email 형식에 맞지 않거나, null 값을 받았을 때, 그럴 때 발생
     @PostMapping("/join")
     public ResponseEntity<String> join(@Valid @RequestBody JoinRequestDTO req) {
-        String username = memberService.join(req);
-        return ResponseEntity.status(HttpStatus.CREATED).body(username);
+        try{
+            if (!emailService.verifyAuthCode(req.getEmail(), req.getAuthcode())) {
+                return ResponseEntity.status(400).body("Email Verification");
+            }
+            String username = memberService.join(req);
+            return ResponseEntity.status(HttpStatus.CREATED).body(username); //201
+        } catch (IllegalArgumentException e) { 
+            return ResponseEntity.status(400).body(e.getMessage()); //아이디 혹은 이메일 중복
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(e.getMessage());
+        }
     }
 
     //키워드 저장
+    //400 에러는 형식에 맞지 않거나, null 값을 받았을 때, 그럴 때 발생
     @PatchMapping("/keywords")
     public ResponseEntity<Void> updateKeywords(@Valid @RequestBody UpdateKeywordRequestDto req) {
-        memberService.updateKeyword(req);
-        return ResponseEntity.noContent().build();
+        try{
+            memberService.updateKeyword(req);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     //로그인
     @PostMapping("/sign-in")
     public ResponseEntity<JwtToken> signIn(@Valid @RequestBody LoginRequestDTO req){
-        JwtToken token = memberService.signIn(req.getUsername(), req.getPassword());
-        return ResponseEntity.ok(token);
+        try{
+            JwtToken token = memberService.signIn(req.getUsername(), req.getPassword());
+            return ResponseEntity.ok(token);
+        } catch (IllegalArgumentException e) { //로그인 에러
+            return ResponseEntity.status(401).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     //이메일로 아이디 찾기
+    //400 에러는 이메일 형식이 안 맞거나 null일 때
     @PostMapping("/find-username")
     public ResponseEntity<String> findUsernameByEmail(@Valid @RequestBody FindIdRequestDTO req){
-        String username = memberService.findUsernameByEmail(req);
-        return ResponseEntity.ok(username);
+        try{
+            String username = memberService.findUsernameByEmail(req);
+            return ResponseEntity.ok(username);
+        } catch (IllegalArgumentException e) { //존재하지 않을 때
+            return ResponseEntity.status(401).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     //비밀번호 찾기(임시 비밀번호 사용)
     @PostMapping("/find-password/temp")
     public ResponseEntity<Void> sendPasswordEmail(@Valid @RequestBody TempPasswordRequestDto req) {
-        emailService.sendTemporaryPassword(req.getUsername(), req.getEmail());
-        return ResponseEntity.noContent().build();
+        try{
+            emailService.sendTemporaryPassword(req.getUsername(), req.getEmail());
+            return ResponseEntity.noContent().build(); //204
+        } catch (IllegalArgumentException e) { //존재하지 않을 때
+            return ResponseEntity.status(401).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
+    
     }
 
     //---개인정보 수정 로직---
 
     //프로필 조회 전 비밀번호 검증
+    //400 입력을 안하면
     @PostMapping("/profile/verify")
     public ResponseEntity<Void> verifyProfilePassword(@Valid @RequestBody VerifyPasswordRequestDto req){
-        memberService.verifyCurrentPassword(req.getPassword());
-        return ResponseEntity.ok().build();
+        try{
+            memberService.verifyCurrentPassword(req.getPassword());
+            return ResponseEntity.ok().build(); //200
+        } catch (IllegalArgumentException e) { //비밀번호가 틀렸을 때
+            return ResponseEntity.status(401).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     //프로필 확인(내 정보 조회) -> 수정 필요
     @GetMapping("/profile/me")
     public ResponseEntity<MemberDto> getCurrentProfile() {
-        MemberDto dto = memberService.getCurrentMember();
-        return ResponseEntity.ok(dto);
+        try{
+            MemberDto dto = memberService.getCurrentMember();
+            return ResponseEntity.ok(dto); //200
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 8) 프로필 변경
-    @PutMapping("/profile/update-profile")
-    public ResponseEntity<MemberDto> updateProfile(
-            @Valid @RequestBody MemberProfileEditRequestDto req
+    //400은 이메일 형식 그런 거 안 지켰을 때 발생
+    @PutMapping("/profile/me")
+    public ResponseEntity<MemberDto> updateProfile(@Valid
+             @RequestBody MemberProfileEditRequestDto req
     ) {
-        MemberDto updated = memberService.updateProfile(req);
-        return ResponseEntity.ok(updated);
+        try{
+            MemberDto updated = memberService.updateProfile(req);
+            return ResponseEntity.ok(updated); //200
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 9) 비밀번호 변경
     @PutMapping("/profile/update-password")
-    public ResponseEntity<Void> changePassword(
-            @Valid @RequestBody UpdatePasswordRequestDto req
+    public ResponseEntity<Void> changePassword(@Valid 
+           @RequestBody UpdatePasswordRequestDto req
     ) {
-        memberService.updatePassword(req);
-        return ResponseEntity.noContent().build();
+        try{
+            memberService.updatePassword(req);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) { //비밀번호가 틀렸을 때
+            return ResponseEntity.status(401).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 자신이 쓴 게시글 확인
+    //실 실행은 나중에
     @GetMapping("/profile/myarticle")
     public ResponseEntity<List<ArticleDto>> getMyArticles() {
         List<ArticleDto> articles = articleService.getMyArticles();
@@ -135,11 +201,16 @@ MemberController {
     @PostMapping("/profile/announcement")
     public ResponseEntity<ArticleDto> createAnnouncement(
             @RequestBody AnnouncementRequestDto requestDto) {
-
-        ArticleDto created = announcementService.createAnnouncement(requestDto);
-        return ResponseEntity
+        try{
+            ArticleDto created = announcementService.createAnnouncement(requestDto);
+            return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(created);
+                .body(created); //201
+        } catch(AccessDeniedException e){
+            return ResponseEntity.status(401).build(); //권한 부족
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 공지사항 수정
@@ -147,16 +218,27 @@ MemberController {
     public ResponseEntity<ArticleDto> updateAnnouncement(
             @PathVariable Long id,
             @RequestBody AnnouncementUpdateRequestDto requestDto) {
-
-        ArticleDto updated = announcementService.updateAnnouncement(id, requestDto);
-        return ResponseEntity.ok(updated);
+        try{
+            ArticleDto updated = announcementService.updateAnnouncement(id, requestDto);
+            return ResponseEntity.ok(updated); //200
+        } catch(AccessDeniedException e){
+            return ResponseEntity.status(401).build(); //권한 부족
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // 공지사항 삭제
     @DeleteMapping("/profile/announcement/{id}")
     public ResponseEntity<Void> deleteArticle(@PathVariable Long id) {
-        announcementService.deleteAnnouncement(id);
-        return ResponseEntity.noContent().build();
+        try{
+            announcementService.deleteAnnouncement(id);
+            return ResponseEntity.noContent().build(); //204
+        } catch(AccessDeniedException e){
+            return ResponseEntity.status(401).build(); //권한 부족
+        } catch (Exception e) {
+            return ResponseEntity.status(500).build();
+        }
     }
 
     //1:1 이메일 문의
@@ -167,7 +249,7 @@ MemberController {
             @RequestBody InquiryRequestDto requestDto) {
 
         emailService.sendInquiry(requestDto);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent().build(); //204
     }
 
     // --- JWT 토큰 재발급 ---

--- a/src/main/java/cultureinfo/culture_app/controller/MemberController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/MemberController.java
@@ -175,7 +175,6 @@ MemberController {
     }
 
     // 자신이 쓴 게시글 확인
-    //실 실행은 나중에
     @GetMapping("/profile/myarticle")
     public ResponseEntity<List<ArticleDto>> getMyArticles() {
         List<ArticleDto> articles = articleService.getMyArticles();

--- a/src/main/java/cultureinfo/culture_app/dto/request/JoinEmailRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/JoinEmailRequestDto.java
@@ -1,0 +1,18 @@
+package cultureinfo.culture_app.dto.request;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class JoinEmailRequestDto {
+
+    @Email @NotBlank
+    private String email;
+
+}

--- a/src/main/java/cultureinfo/culture_app/dto/request/JoinRequestDTO.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/JoinRequestDTO.java
@@ -18,4 +18,5 @@ public class JoinRequestDTO {
     @NotNull private Gender gender;
     @NotBlank private String location;
     @NotBlank private String nickname;
+    @NotBlank private String authcode;
 }

--- a/src/main/java/cultureinfo/culture_app/dto/request/MemberProfileEditRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/MemberProfileEditRequestDto.java
@@ -14,8 +14,6 @@ import lombok.NoArgsConstructor;
 public class MemberProfileEditRequestDto {
     @NotBlank
     private String name;
-    @NotBlank
-    private String currentPassword;
     @Email @NotBlank
     private String email;
     @NotBlank

--- a/src/main/java/cultureinfo/culture_app/dto/request/MemberProfileEditRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/MemberProfileEditRequestDto.java
@@ -4,6 +4,7 @@ package cultureinfo.culture_app.dto.request;
 import cultureinfo.culture_app.domain.type.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -16,7 +17,7 @@ public class MemberProfileEditRequestDto {
     private String name;
     @Email @NotBlank
     private String email;
-    @NotBlank
+    @NotNull
     private Gender gender;
     @NotBlank
     private String location;

--- a/src/main/java/cultureinfo/culture_app/service/MemberService.java
+++ b/src/main/java/cultureinfo/culture_app/service/MemberService.java
@@ -41,6 +41,9 @@ public class MemberService {
         if (memberRepository.existsByEmail(joinRequestDTO.getEmail())) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
+        if (memberRepository.existsByEmail(joinRequestDTO.getNickname())) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
 
         String encodedPassword = passwordEncoder.encode(joinRequestDTO.getPassword());
 

--- a/src/main/java/cultureinfo/culture_app/service/MemberService.java
+++ b/src/main/java/cultureinfo/culture_app/service/MemberService.java
@@ -165,7 +165,6 @@ public class MemberService {
     //프로필 변경
     @Transactional
     public MemberDto updateProfile(MemberProfileEditRequestDto req) {
-        verifyCurrentPassword(req.getCurrentPassword());
 
         Long userId = securityUtil.getCurrentId();
         Member member = memberRepository.findById(userId)


### PR DESCRIPTION
1. MemberController, CommentController, CommentLikeController, ArticleController, ArticleLikeController 작동 확인
2. 모든 에러가 403에러가 나는데 이를 SecurityConfig 내에서 /error를 permitall() 함으로써 방지
3. 형식 오류는 400에러, 입력 받은 정보가 DB와 다르거나 인증 오류가 있을 때나, 권한부족일 때 401에러, 토큰이 만료되면 403에러 발생하도록 수정
4. /join/send-email에서 RequestParam으로 메일을 받던 것을 dto 추가하여 RequestBody로 받게 수정(통일성을 위해서)
5. 프로필 조회/수정 기능이 각각의 페이지가 아닌 한 페이지 내에서 가능하게 수정
6. 회원가입 시 인증코드를 기입하도록 수정
7. 회원가입 시 닉네임 중복을 막게 수정