### PR TITLE
refactor: 기존 join 안에 있던 email 인증을 따로 빼서 확인할 수 있도록 수정

### DIFF
--- a/src/main/java/cultureinfo/culture_app/config/SecurityConfig.java
+++ b/src/main/java/cultureinfo/culture_app/config/SecurityConfig.java
@@ -97,7 +97,7 @@ public class SecurityConfig {
             @Override
             public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
                 CorsConfiguration configuration = new CorsConfiguration();
-                configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                configuration.setAllowedOrigins(Collections.singletonList("*"));
                 configuration.setAllowedMethods(Collections.singletonList("*"));
                 configuration.setAllowCredentials(true);
                 configuration.setAllowedHeaders(Collections.singletonList("*"));

--- a/src/main/java/cultureinfo/culture_app/controller/MemberController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/MemberController.java
@@ -45,11 +45,12 @@ MemberController {
             return ResponseEntity.noContent().build(); //204
     }
 
+
     //회원가입
     //400 에러는 email 형식에 맞지 않거나, null 값을 받았을 때, 그럴 때 발생
     @PostMapping("/join")
     public ResponseEntity<String> join(@Valid @RequestBody JoinRequestDTO req) {
-        emailService.verifyAuthCode(req.getEmail(), req.getAuthcode());
+        emailService.checkEmailVerified(req.getEmail());
         String username = memberService.join(req);
         return ResponseEntity.status(HttpStatus.CREATED).body(username); //201
     }
@@ -58,6 +59,13 @@ MemberController {
     @PostMapping("/join/verify-username")
     public ResponseEntity<Void> verifyUsername(@Valid @RequestBody JoinUsernameRequestDto username){
         memberService.verifyUsername(username.getUsername());
+        return ResponseEntity.ok().build();
+    }
+
+    //이메일 코드 인증
+    @PostMapping("join/verify-emailcode")
+    public ResponseEntity<Void> verifyEmailCode(@RequestBody EmailVerifyRequestDto req) {
+        emailService.verifyAuthCode(req.getEmail(), req.getAuthcode());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/cultureinfo/culture_app/dto/request/EmailVerifyRequestDto.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/EmailVerifyRequestDto.java
@@ -1,0 +1,19 @@
+package cultureinfo.culture_app.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+//이메일 코드 인증용 dto
+public class EmailVerifyRequestDto {
+    @Email
+    @NotBlank
+    private String email;
+    @NotBlank
+    private String authcode;
+}

--- a/src/main/java/cultureinfo/culture_app/dto/request/JoinRequestDTO.java
+++ b/src/main/java/cultureinfo/culture_app/dto/request/JoinRequestDTO.java
@@ -19,5 +19,4 @@ public class JoinRequestDTO {
     @NotBlank private String location;
     @NotBlank private String nickname;
     @NotNull private Long age;
-    @NotBlank private String authcode;
 }

--- a/src/main/java/cultureinfo/culture_app/exception/ErrorCode.java
+++ b/src/main/java/cultureinfo/culture_app/exception/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     AUTH_CODE_MISMATCH("AUTH_011", HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
     TEMP_PASSWORD_SAVE_FAILED("USER_010", HttpStatus.INTERNAL_SERVER_ERROR, "임시 비밀번호 저장에 실패했습니다."),
     INQUIRY_SEND_FAILED("MAIL_002", HttpStatus.BAD_GATEWAY, "문의 이메일 전송에 실패했습니다."),
+    EMAIL_NOT_VERIFIED("MAIL_003",HttpStatus.BAD_REQUEST, "이메일 인증에 실패했습니"),
+
 
     // 파일
     FILE_UPLOAD_FAILED("FILE_001", HttpStatus.BAD_GATEWAY, "파일 업로드 중 오류가 발생했습니다."),

--- a/src/main/java/cultureinfo/culture_app/service/EmailService.java
+++ b/src/main/java/cultureinfo/culture_app/service/EmailService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import cultureinfo.culture_app.dto.request.InquiryRequestDto;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -197,6 +198,18 @@ public class EmailService {
         }
         if (!stored.equals(inputCode)) {
             throw new CustomException(ErrorCode.AUTH_CODE_MISMATCH);
+        }
+
+        // 인증 완료 표시 저장 10분간
+        valueOperations.set("verified:" + email, "true", Duration.ofMinutes(10));
+    }
+
+    //인증된 이메일인지 확인
+    public void checkEmailVerified(String email) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String verified = valueOperations.get("verified:" + email);
+        if (!"true".equals(verified)) {
+            throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
         }
     }
 


### PR DESCRIPTION
	•	JoinRequestDTO에서 authcode 필드 제거
	•	이메일 인증 전용 API 추가: POST /api/members/join/verify-code
	•	인증 성공 시 Redis에 "verified:{email}" = true" 저장
	•	회원가입 시 이메일 인증 여부(checkEmailVerified) 확인하도록 변경
	•	관련 예외 코드 EMAIL_NOT_VERIFIED 메시지를 "이메일 인증에 실패했습니다."로 명확하게 수정
	•	플러터 클라이언트에서 인증번호 입력 후 별도 인증 확인 요청 추가
	•	/join 요청에서는 인증번호 제외