### PR TITLE
검색수정

### DIFF
--- a/src/main/java/cultureinfo/culture_app/controller/ContentDetailController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/ContentDetailController.java
@@ -27,14 +27,14 @@ public class ContentDetailController {
 
     // 목록 조회: 대분류(main), 중분류(sub), 소분류(small) 모두 옵션으로 받아 필터링
 
-    @GetMapping
+    @PostMapping("/search")
     public Slice<ContentSummaryDto> search(@Valid @RequestBody ContentSearchRequestDto req) {
         return contentDetailService.searchByKeyword(req);
     }
-
     /** 2. 대분류 전체 조회
      * GET /api/contents/categories
      */
+
     @GetMapping("/categories")
     public List<ContentCategoryDto> getAllCategories() {
         return contentDetailService.getAllContentCategories();
@@ -76,7 +76,6 @@ public class ContentDetailController {
         return contentDetailService.getContentDetail(id);
     }
 
-
      // 콘텐츠 생성
      // POST /api/contents
     @PostMapping
@@ -85,7 +84,6 @@ public class ContentDetailController {
     ) {
         return contentDetailService.createContentDetail(req);
     }
-
 
      // 콘텐츠 수정
      // PUT /api/contents/{id}
@@ -97,10 +95,8 @@ public class ContentDetailController {
         return contentDetailService.updateContentDetail(id, req);
     }
 
-
      // 콘텐츠 삭제
      // DELETE /api/contents/{id}
-
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         contentDetailService.deleteContentDetail(id);

--- a/src/main/java/cultureinfo/culture_app/repository/ContentDetailRepositoryCustomImpl.java
+++ b/src/main/java/cultureinfo/culture_app/repository/ContentDetailRepositoryCustomImpl.java
@@ -34,15 +34,19 @@ public class ContentDetailRepositoryCustomImpl implements ContentDetailRepositor
     ) {
         BooleanBuilder builder = new BooleanBuilder();
 
-        //ContentDetail -> 소분류 -> 중분류 -> 대분류의 id가 categoryId와 일치하는 콘텐츠만 검색
-        //타입 안전
-        //연관관계 자동 조인
+        //조건이 있을 경우에만 필터링 하도록 (없으면 전체 조회)
+        if (subCategoryId != null) {
+            builder.and(contentDetail.contentSubcategory.id.eq(subCategoryId));
+        }
 
         // 키워드 기반 검색 ex) '대동제' 검색 시 '2025 동국대 대동제' 검색됨
         if (keyword!=null&&!keyword.isBlank()) builder.and(contentDetail.contentName.containsIgnoreCase(keyword));
 
+        //subjectName(가수, 연예인 등)이 포함된 경우
         if (subjectName!=null&&!subjectName.isBlank())
             builder.and(contentDetail.subjectNames.any().containsIgnoreCase(subjectName));
+
+        //조건에 맞는 콘텐츠 페이징 조회
         return fetchSlice(builder, sortBy, pageable, memberId);
     }
 
@@ -103,8 +107,6 @@ public class ContentDetailRepositoryCustomImpl implements ContentDetailRepositor
                 .toList();
         return new SliceImpl<>(result, pageable, hasNext);
     }
-
-
 
 }
 


### PR DESCRIPTION
🎯 목적
	•	콘텐츠 검색 페이지 초기 진입 시, 조건 없이 전체 콘텐츠 리스트가 출력되도록 기능 수정
	•	복잡한 검색 조건을 JSON으로 받기 위해 @GetMapping → @PostMapping으로 변경

⸻

🔧 주요 변경 사항
	1.	subCategoryId 조건 분기 추가
	•	기존에는 subCategoryId가 null이어도 무조건 조건에 포함되어 전체 검색이 되지 않음
	•	if (subCategoryId != null) 조건문으로 수정하여, 값이 있을 때만 필터링되도록 변경
	•	→ subCategoryId, keyword, subjectName이 모두 없으면 전체 리스트 반환됨
	2.	GET → POST 요청 방식 변경
	•	기존: @GetMapping + @RequestBody (HTTP 표준 위반 및 호환성 문제)
	•	변경: @PostMapping("/search") + @RequestBody로 정상적인 JSON 검색 조건 처리
	•	→ Flutter 등 클라이언트에서 안정적으로 요청 가능