### PR TITLE
refactor: 검색 및 조회가 subCategory에서만 이루어 질 수 있도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.log
 *.ctxt
 .mtj.tmp/
-.yml
+*.yml
 
 # === Archives ===
 *.jar

--- a/src/main/java/cultureinfo/culture_app/controller/ArticleController.java
+++ b/src/main/java/cultureinfo/culture_app/controller/ArticleController.java
@@ -36,23 +36,27 @@ public class ArticleController {
         return ResponseEntity.ok(article);
     }
 
+    //조회 검색은 트정 중분류에서만 되도록
+
     // 게시글 전체 조회 -> slice 적용
-    @GetMapping
+    @GetMapping("/{subCategoryId}")
     public ResponseEntity<Slice<ArticleSummaryDto>> getAll(
+            @PathVariable Long subCategoryId,
             @PageableDefault(size = 20, sort = "createDate", direction = Sort.Direction.DESC)
             Pageable pageable){
-        Slice<ArticleSummaryDto> slice = articleService.getAllArticles(pageable);
+        Slice<ArticleSummaryDto> slice = articleService.getAllArticles(subCategoryId, pageable);
         return ResponseEntity.ok(slice);
     }
 
 
     //게시글 검색 -> slice 적용
-    @GetMapping("/search")
+    @GetMapping("/{subCategoryId}/search")
     public ResponseEntity<Slice<ArticleSummaryDto>> searchArticles(
+            @PathVariable Long subCategoryId,
             @RequestParam String keyword,
             @PageableDefault(size = 20, sort = "createDate", direction = Sort.Direction.DESC)
             Pageable pageable) {
-        Slice<ArticleSummaryDto> slice = articleService.searchArticles(keyword, pageable);
+        Slice<ArticleSummaryDto> slice = articleService.searchArticles(subCategoryId,keyword, pageable);
         return ResponseEntity.ok(slice);
     }
 

--- a/src/main/java/cultureinfo/culture_app/domain/ContentSession.java
+++ b/src/main/java/cultureinfo/culture_app/domain/ContentSession.java
@@ -41,5 +41,4 @@ public class ContentSession {
     public void changeBooths(List<String> booths) {
         this.booths = booths;
     }
-
 }

--- a/src/main/java/cultureinfo/culture_app/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/cultureinfo/culture_app/repository/ArticleRepositoryCustom.java
@@ -7,8 +7,8 @@ import org.springframework.data.domain.Slice;
 //querydsl을 사용하기 위한 커스텀 저장소 정의
 public interface ArticleRepositoryCustom {
     //키워드 검색 + Slice(무한 스크롤용)
-    Slice<Article> searchByKeyword(String keyword, Pageable pageable);
+    Slice<Article> searchByKeyword(Long subCategoryId, String keyword, Pageable pageable);
 
     //slice 적용한 전체 게시글 조회
-    Slice<Article> findAllBy(Pageable pageable);
+    Slice<Article> findAllBy(Long subCategoryId, Pageable pageable);
 }

--- a/src/main/java/cultureinfo/culture_app/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/cultureinfo/culture_app/repository/ArticleRepositoryImpl.java
@@ -19,7 +19,7 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
 
     //게시글 검색
     @Override
-    public Slice<Article> searchByKeyword(String keyword, Pageable pageable) {
+    public Slice<Article> searchByKeyword(Long subCategoryId, String keyword, Pageable pageable) {
         QArticle article = QArticle.article;
 
         //실제로 조회할 개수 + 1 (hasNext 판별용)
@@ -28,10 +28,12 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
         List<Article> fetched = queryFactory
                 .selectFrom(article)
                 .where(
-                        //제목에 키워드가 있거나
-                        article.title.containsIgnoreCase(keyword)
-                                //본문에 키워드가 있거나
-                                .or(article.body.containsIgnoreCase(keyword))
+                        article.subCategory.id.eq(article.subCategory.id)
+                                .and(//제목에 키워드가 있거나
+                                        article.title.containsIgnoreCase(keyword)
+                                                //본문에 키워드가 있거나
+                                        .or(article.body.containsIgnoreCase(keyword)))
+
                 )
                 //날짜순 내림차순 정렬
                 .orderBy(article.createDate.desc())
@@ -51,12 +53,13 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
     }
 
     @Override
-    public Slice<Article> findAllBy(Pageable pageable){
+    public Slice<Article> findAllBy(Long subCategoryId, Pageable pageable){
         QArticle article = QArticle.article;
         int size = pageable.getPageSize();
 
         List<Article> fetched = queryFactory
                 .selectFrom(article)
+                .where(article.subCategory.id.eq(article.subCategory.id))
                 .orderBy(article.createDate.desc())
                 .offset(pageable.getOffset())
                 .limit(size + 1)

--- a/src/main/java/cultureinfo/culture_app/service/ArticleService.java
+++ b/src/main/java/cultureinfo/culture_app/service/ArticleService.java
@@ -65,17 +65,17 @@ public class ArticleService {
 
     @Transactional(readOnly = true)
     // 전체 조회
-    public Slice<ArticleSummaryDto> getAllArticles(Pageable pageable) {
+    public Slice<ArticleSummaryDto> getAllArticles(Long subCategoryId, Pageable pageable) {
         // Slice<Article>을 리포지토리에서 받아오고
-        Slice<Article> slice = articleRepository.findAllBy(pageable);
+        Slice<Article> slice = articleRepository.findAllBy(subCategoryId, pageable);
         // DTO 로 매핑한 Slice 반환
         return slice.map(ArticleSummaryDto::from);
     }
 
     //검색(제목 or 본문의 일부 내용 입력 시 검색 가능)
     @Transactional(readOnly = true)
-    public Slice<ArticleSummaryDto> searchArticles(String keyword, Pageable pageable) {
-        Slice<Article> slice = articleRepository.searchByKeyword(keyword, pageable);
+    public Slice<ArticleSummaryDto> searchArticles(Long subCategoryId, String keyword, Pageable pageable) {
+        Slice<Article> slice = articleRepository.searchByKeyword(subCategoryId, keyword, pageable);
         // DTO로 매핑한 Slice 반환
         return slice.map(ArticleSummaryDto::from);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   # jpa
   jpa:
     hibernate:
-      ddl-auto: create        # 앱 실행 시 테이블을 **항상 새로 생성** (기존 데이터 삭제됨)
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
✨ 변경 내용 (Refactor)
	•	게시글 조회 및 검색 로직을 중분류(subCategory) 기준으로 제한하도록 수정
	•	게시판은 중분류별로 하나씩 존재하며,
해당 게시판 안에서만 게시글 전체 조회 및 검색이 가능하도록 API 구조 변경

⸻

🔧 주요 수정 사항
	•	GET /articles/{subCategoryId}
→ 중분류 ID에 해당하는 게시판의 전체 게시글 목록 조회
	•	GET /articles/{subCategoryId}/search?keyword=XXX
→ 중분류 ID에 해당하는 게시판 내에서만 게시글 검색 가능
	•	서비스, 레포지토리 계층에서도 중분류 기반 필터링을 적용

⸻

📌 기타
	•	클라이언트(Flutter)에서는 쿼리 파라미터 기반으로 요청